### PR TITLE
Fix spawn start date

### DIFF
--- a/Parameters/Temperature/fun_temp_analysis.R
+++ b/Parameters/Temperature/fun_temp_analysis.R
@@ -17,7 +17,10 @@ temp_analysis <- df %>%
          Start_spawn = mdy(Start_spawn),
          End_spawn = mdy(End_spawn),
          # If Spawn dates span a calendar year, account for year change in spawn end date
-         End_spawn = if_else(End_spawn < Start_spawn, End_spawn + years(1), End_spawn ),
+         End_spawn = if_else(End_spawn < Start_spawn & sample_datetime >= End_spawn, End_spawn + years(1), # add a year if in spawn period carrying to next year
+                             End_spawn),
+         Start_spawn = if_else(End_spawn < Start_spawn & sample_datetime <= End_spawn, Start_spawn - years(1), # subtract a year if in spawn period carrying from previous year
+                               Start_spawn),
          SampleStartDate = ymd(SampleStartDate), 
          # Flag for results in critical period
          In_crit_period = ifelse(SampleStartDate >=Crit_period_start & SampleStartDate <= Cirt_period_end, 1, 0 ),


### PR DESCRIPTION
Correct error in handling spawning periods that span a year. Previously, code was not working correctly when the spawn start date was in the year before the sample date.