### PR TITLE
DO Fix

### DIFF
--- a/Parameters/DO/fun_DO_spawn.R
+++ b/Parameters/DO/fun_DO_spawn.R
@@ -205,8 +205,9 @@ cont_spawn_DO_categories <- cont_spawn_Do_analysis %>%
             #num_valid_samples = sum(!is.na(Violation)),
             num_violations = sum(Violation, na.rm = TRUE)) %>%
   left_join(daily_minimums, by = 'AU_ID') %>%
-  mutate(IR_category = ifelse(num_violations >= 2 | num_below_abs_min >= 2 , "Cat 5", 
-                           "Cat 2" )) #%>%
+  mutate(IR_category = case_when(num_violations >= 2 | num_below_abs_min >= 2 ~ "Cat 5",
+                                 TRUE ~ "Cat 2"))
+           
  # mutate(type = "Spawning continuous")
 
 #write table here
@@ -329,13 +330,11 @@ instant_DO_sat_categories <- instant_DO_sat_analysis %>%
             num_samples = n(),
             num_Violations = sum(Violation, na.rm = TRUE)) %>%
   mutate(critical_excursions = excursions_conv(num_samples)) %>%
-  mutate(IR_category = ifelse(num_samples < 5 &
-                             num_Violations == 0, "Cat 3", 
-                           ifelse(num_samples < 5 &
-                                    num_Violations > 0, "Cat 3B", 
-                                  ifelse(num_samples > 5 & num_Violations >= critical_excursions, "Cat 5", 
-                                         ifelse(num_samples > 5 & num_Violations < critical_excursions, "Cat 2",  
-                                                "ERROR"))))) %>%
+  mutate(IR_category = case_when(num_samples < 5 & num_Violations == 0 ~ "Cat 3",
+                                 num_samples < 5 & num_Violations > 0 ~ "Cat 3B",
+                                 num_samples >= 5 & num_Violations >= critical_excursions ~  "Cat 5",
+                                 num_samples >= 5 & num_Violations < critical_excursions ~ "Cat 2",
+                                 TRUE ~ 'ERROR')) %>%
   mutate(type = "Spawning instant")
 
 # Write table here


### PR DESCRIPTION
Instantaneous year round IR categorization was missing a condition for when there are exactly 5 samples. Original code had left out the equal sign when determining if there were 5 or more samples. 